### PR TITLE
add missing array include

### DIFF
--- a/src/DiscoverDevices.cc
+++ b/src/DiscoverDevices.cc
@@ -13,6 +13,7 @@ static const char* LOG_TAG = "Utilities";
 #include <regex>
 #include <string>
 #include <sstream>
+#include <array>
 
 namespace RealSenseID
 {


### PR DESCRIPTION
Hi there,
Since array is used in Linux implementation, it should be included:
https://github.com/IntelRealSense/RealSenseID/blob/eeebae46401e9eea5af5487d3e512e675b435349/src/DiscoverDevices.cc#L251