### PR TITLE
compatibility with all openSUSE

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ For high-level architecture, see [Intel RealSense ID F450 / F455 Architecture Di
 Note: Device = Intel RealSense ID F450 / F455
 
 ## Platforms
- * Linux (tested on ubuntu 18, gcc 7.5+)
+ * Linux (tested on ubuntu 18, [openSUSE Leap 15.1, 15.2, 15.3 RC and Tumbleweed](https://news.opensuse.org/2021/05/19/RealSenseID-available-for-openSUSE/) gcc 7.5+)
  * Windows (tested on windows 10, msvc 2019)
  * Android (tested on Android 6.0 but should also work on newer versions)
 


### PR DESCRIPTION
As an openSUSE ambassador and founder of the openSUSE Innovators initiative, I homologated the  RealSenseID on all openSUSE Linux.

https://news.opensuse.org/
https://news.opensuse.org/2021/05/19/RealSenseID-available-for-openSUSE/
https://en.opensuse.org/SDB:Install_RealSenseID