### PR TITLE
Made the whitespace trimming less fragile

### DIFF
--- a/src/DiscoverDevices.cc
+++ b/src/DiscoverDevices.cc
@@ -236,6 +236,7 @@ namespace RealSenseID
 {
 static const std::string V4L_PATH = "/sys/class/video4linux/";
 static const std::string V4L_CAM_ID_PATH = "/device/*/*/id/";
+static const std::string WHITESPACE_CHARS = " \t\n";
 static const int FAILED_V4L = -1;
 
 static void ThrowIfFailed(char* what, int res)
@@ -260,12 +261,7 @@ static std::string ExecuteCmd(const std::string cmd)
     {
         result += buffer.data();
     }
-    if (!result.empty())
-    {
-        result.pop_back();
-    }
-    result.pop_back();
-    return result;
+    return result.substr(0, result.find_last_not_of(WHITESPACE_CHARS)+1);
 }
 
 std::vector<int> DiscoverCapture()


### PR DESCRIPTION
For some reason my `wc` output has only one whitespace character at the end of its output instead of - as assumed in this function - two. This caused the following exception to be raised:

```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoi
```

My understanding is that the idea behind the `pop_back()` calls are to trim the whitespace from the end of the command output, so I've replaced this with an implementation that should not depend on the exact number of whitespace characters.