### PR TITLE
Enable macOS build for the face-auth path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,7 @@ See [SKILL.md](./SKILL.md) for guidance when using this SDK with AI tools.
 
 - Linux (Ubuntu 18.04+, Raspberry Pi 4+, Jetson)
 - Windows (Windows 10+)
+- macOS 12+ (Apple Silicon; face-auth path only — preview/libuvc unsupported)
 - Android 8-16
 
 ## Bindings
@@ -146,6 +147,16 @@ In order to be able to capture metadata for RAW format, open a `PowerShell` term
 
 # F500 / F505
 .\scripts\realsenseid_metadata_win10-f500.ps1
+```
+
+### macOS Notes
+
+The face-auth path (FaceAuthenticator, DeviceController, FwUpdater) builds and runs on macOS using the existing POSIX `LinuxSerial` implementation. Build with `-DRSID_PREVIEW=OFF`; the preview pipeline (libuvc) is not yet supported on macOS.
+
+`discover_devices()` walks `/sys/bus/usb/` (Linux-only) and returns an empty list on macOS. Pass the F455's serial port directly to `FaceAuthenticator(<port>)`. Locate it with:
+
+```bash
+ls /dev/cu.usbmodem*
 ```
 
 ## Sample Code

--- a/cmake/OS.cmake
+++ b/cmake/OS.cmake
@@ -7,6 +7,9 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     message(STATUS "Linux platform")
     add_definitions(-DLINUX)
 
+elseif(APPLE)
+    message(STATUS "macOS platform")
+
 elseif(ANDROID)
     message(STATUS "Android platform")
     add_definitions(-DANDROID_STL=c++_shared)

--- a/src/DeviceController/DeviceControllerImpl.cc
+++ b/src/DeviceController/DeviceControllerImpl.cc
@@ -20,7 +20,7 @@
 #include "PacketManager/WindowsSerial.h"
 #elif defined(__ANDROID__)
 #include "PacketManager/AndroidSerial.h"
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include "PacketManager/LinuxSerial.h"
 #else
 #error "Platform not supported"
@@ -60,7 +60,7 @@ Status DeviceControllerImpl::Connect(const SerialConfig& config)
         serial_config.readEndpoint = config.readEndpoint;
         serial_config.writeEndpoint = config.writeEndpoint;
         _serial = std::make_unique<PacketManager::AndroidSerial>(serial_config);
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
         _serial = std::make_unique<PacketManager::LinuxSerial>(PacketManager::SerialConfig({config.port}));
 #else
         LOG_ERROR(LOG_TAG, "Serial connection method not supported for OS");

--- a/src/FaceAuthenticator/Impl/FaceAuthenticatorCommon.cc
+++ b/src/FaceAuthenticator/Impl/FaceAuthenticatorCommon.cc
@@ -28,7 +28,7 @@
 #include "PacketManager/WindowsSerial.h"
 #elif defined(__ANDROID__)
 #include "PacketManager/AndroidSerial.h"
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include "PacketManager/LinuxSerial.h"
 #else
 #error "Platform not supported"
@@ -227,7 +227,7 @@ Status FaceAuthenticatorCommon::Connect(const SerialConfig& config)
         serial_config.readEndpoint = config.readEndpoint;
         serial_config.writeEndpoint = config.writeEndpoint;
         _serial = std::make_unique<PacketManager::AndroidSerial>(serial_config);
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
         _serial = std::make_unique<PacketManager::LinuxSerial>(PacketManager::SerialConfig({config.port}));
 #else
         LOG_ERROR(LOG_TAG, "Serial connection method not supported for OS");

--- a/src/FwUpdate/F45x/FwUpdaterCommF45x.cc
+++ b/src/FwUpdate/F45x/FwUpdaterCommF45x.cc
@@ -16,7 +16,7 @@
 #include "PacketManager/WindowsSerial.h"
 #elif defined(__ANDROID__)
 #include "PacketManager/AndroidSerial.h"
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include "PacketManager/LinuxSerial.h"
 #else
 #error "Platform not supported"
@@ -42,7 +42,7 @@ FwUpdaterCommF45x::FwUpdaterCommF45x(const SerialConfig& config)
     serial_config.readEndpoint = config.readEndpoint;
     serial_config.writeEndpoint = config.writeEndpoint;
     _serial = std::make_unique<PacketManager::AndroidSerial>(serial_config);
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
     _serial = std::make_unique<PacketManager::LinuxSerial>(PacketManager::SerialConfig({config.port}));
 #else
     throw std::runtime_error("FwUpdaterComm not supported for this OS yet");

--- a/src/FwUpdate/F50x/FwUpdaterCommF50x.cc
+++ b/src/FwUpdate/F50x/FwUpdaterCommF50x.cc
@@ -15,7 +15,7 @@
 #include "PacketManager/WindowsSerial.h"
 #elif defined(__ANDROID__)
 #include "PacketManager/AndroidSerial.h"
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include "PacketManager/LinuxSerial.h"
 #else
 #error "Platform not supported"
@@ -41,7 +41,7 @@ FwUpdaterCommF50x::FwUpdaterCommF50x(const SerialConfig& config)
     serial_config.readEndpoint = config.readEndpoint;
     serial_config.writeEndpoint = config.writeEndpoint;
     _serial = std::make_unique<PacketManager::AndroidSerial>(serial_config);
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
     _serial = std::make_unique<PacketManager::LinuxSerial>(PacketManager::SerialConfig({config.port}));
 #else
     throw std::runtime_error("FwUpdaterComm not supported for this OS yet");

--- a/src/PacketManager/CMakeLists.txt
+++ b/src/PacketManager/CMakeLists.txt
@@ -4,7 +4,10 @@ set(HEADERS "${SRC_DIR}/Randomizer.h" "${SRC_DIR}/PacketSender.h" "${SRC_DIR}/Se
 
 set(SOURCES "${SRC_DIR}/Randomizer.cc" "${SRC_DIR}/PacketSender.cc" "${SRC_DIR}/SerialPacket.cc" "${SRC_DIR}/Timer.cc"  ${SRC_DIR}/Crc16.cc )
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR APPLE)
+    # LinuxSerial uses only POSIX serial APIs (termios.h / unistd.h /
+    # fcntl.h) — no Linux-specific syscalls or headers — so the same
+    # implementation builds and runs on macOS unchanged.
     list(APPEND HEADERS "${SRC_DIR}/LinuxSerial.h")
     list(APPEND SOURCES "${SRC_DIR}/LinuxSerial.cc")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")


### PR DESCRIPTION
## Summary

Enables building the face-auth path of the RealSense ID SDK on macOS (Apple Silicon). The existing `LinuxSerial` implementation is pure POSIX, so the same serial transport works unchanged on macOS — the patch just opts macOS into the existing code paths via `APPLE` (CMake) and `__APPLE__` (preprocessor).

## What's included

- `cmake/OS.cmake`: new `APPLE` branch matching the existing `ANDROID` style.
- `src/PacketManager/CMakeLists.txt`: include `LinuxSerial` on macOS, with a comment explaining why reuse is safe.
- Four platform guards extended to also match `__APPLE__`:
  - `DeviceControllerImpl.cc`
  - `FaceAuthenticatorCommon.cc`
  - `FwUpdaterCommF45x.cc`
  - `FwUpdaterCommF50x.cc`
- `Readme.md`: macOS added to Platforms list + macOS Notes subsection.

~10 lines of code across 6 files.

## Out of scope (happy to follow up)

- Preview / `libuvc` support on macOS — `libuvc` is already excluded for Apple upstream. AVFoundation would be the macOS-native replacement.
- IOKit-based `discover_devices()` — the function currently walks `/sys/bus/usb/` and returns an empty list on macOS. Documented as a known limitation in the macOS Notes.

## Tested

- Build: Apple Silicon (M-series), macOS 26, Apple Clang 21, CMake 4.3, Python 3.13, with `-DRSID_PY=ON -DRSID_PREVIEW=OFF`.
- End-to-end face-auth (enroll, identify, query, remove) against an F455 over USB.
- F500 firmware-updater file gets the matching guard but isn't runtime-tested (no F500 hardware on hand).
- Intel Mac not tested.