### PR TITLE
fix(host-mode): handle FaceDistances in ExtractFaceprintsForAuthLoop

### DIFF
--- a/src/FaceAuthenticator/Impl/FaceAuthenticatorCommon.cc
+++ b/src/FaceAuthenticator/Impl/FaceAuthenticatorCommon.cc
@@ -1580,6 +1580,16 @@ Status FaceAuthenticatorCommon::ExtractFaceprintsForAuthLoop(AuthFaceprintsExtra
                 continue; // continue to recv next messages
             }
 
+            // handle face distances as data packet
+            if (msg_id == MsgId::FaceDistances)
+            {
+                unsigned int ts = 0;
+                auto distances = GetFaceDistances(fa_packet, ts);
+                if (!distances.empty())
+                    callback.OnFaceDistances(distances, ts);
+                continue; // continue to recv next messages
+            }
+
             // handle face cropped image data packet
             if (msg_id == MsgId::FaceCroppedImage)
             {


### PR DESCRIPTION
ExtractFaceprintsForAuthLoop did not handle FaceDistances (MsgId 109, 'm'), so firmware 9.16.1.1 caused "Received unexpected MsgId 109 ('m')" and the auth loop failed. Handle the packet the same way as in the authenticate loop: parse distances and invoke OnFaceDistances, then continue.  Tested with host mode 3.6.1 and firmware 9.16.1.1.