### PR TITLE
Security: Remediate vulnerabilities detected by Aikido

### DIFF
--- a/tools/rsid-viewer/UpdateAvailableDialog.xaml.cs
+++ b/tools/rsid-viewer/UpdateAvailableDialog.xaml.cs
@@ -1,4 +1,4 @@
-﻿// License: Apache 2.0. See LICENSE file in root directory.
+// License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020-2021 RealSense, Inc. All Rights Reserved.
 
 using System;
@@ -78,10 +78,20 @@ namespace rsid_wrapper_csharp
 
         private void Hyperlink_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
         {
+            // Security fix: validate URI scheme to prevent command injection via Process.Start.
+            // Only allow http/https URIs to be opened in the browser; reject all other schemes
+            // (e.g. file://, cmd://, ms-settings:, etc.) that could execute arbitrary commands.
+            var uri = e.Uri;
+            if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            {
+                e.Handled = true;
+                return;
+            }
+
             // Open the URL in the system's default web browser
             System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
             {
-                FileName = e.Uri.AbsoluteUri,
+                FileName = uri.AbsoluteUri,
                 UseShellExecute = true
             });
 


### PR DESCRIPTION
## Security Fixes — Aikido Daily Scan (2026-07-29)

This PR remediates security vulnerabilities identified by the Aikido daily scan.

---

### Vulnerability Summary

| Issue ID | Severity | Type | File | Description |
|----------|----------|------|------|-------------|
| 33814494 | 🔴 Critical | SAST | `tools/rsid-viewer/UpdateAvailableDialog.xaml.cs` | Command injection via `Process.Start` |
| 18050753 | 🟠 High | SAST | `samples/android/app/src/main/AndroidManifest.xml` | Improper SSL certificate validation |

---

### Fixes Applied

#### [Critical] Command Injection via `Process.Start` — `UpdateAvailableDialog.xaml.cs`

**Problem:** `Hyperlink_RequestNavigate` passed `e.Uri.AbsoluteUri` directly to `System.Diagnostics.Process.Start` with `UseShellExecute = true`. An attacker who can inject a non-http URI (e.g. `cmd://`, `file://`, `ms-settings:`) into the release info response could trigger arbitrary process execution on the host.

**Fix:** Added explicit URI scheme validation before calling `Process.Start`. Only `http://` and `https://` URIs are permitted; all other schemes are silently rejected with `e.Handled = true`.

```csharp
var uri = e.Uri;
if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
{
    e.Handled = true;
    return;
}
```

---

#### [High] Improper SSL Certificate Validation — `AndroidManifest.xml`

**Status: Already addressed in sample app** — `samples/android/app/src/main/AndroidManifest.xml` already declares `android:networkSecurityConfig="@xml/network_security_config"` and the corresponding `network_security_config.xml` is properly configured with `cleartextTrafficPermitted="false"` and system trust anchors only.

The wrapper library manifests (`wrappers/android/realsenseid/src/secured/AndroidManifest.xml` and `wrappers/android/realsenseid/src/standard/AndroidManifest.xml`) are Android **library** manifests. The `networkSecurityConfig` attribute is an application-level setting and does not apply to library modules — it must be set by the consuming application.

**Action required:** Verify that any consuming application sets `android:networkSecurityConfig` in its own manifest. No code change required in this repo for the library manifests.

---

### Issues Requiring Manual Review (Medium / Low)

| Severity | Type | Description |
|----------|------|-------------|
| Medium | IaC | Docker container runs as root (`Dockerfile`) — add `USER` directive |
| Medium | SAST | Android backup enabled (`android:allowBackup="true"`) |
| Medium | SAST | Android components with `exported` attribute active |
| Medium | SCA | `kotlin-stdlib` — file permissions vulnerability (CVE-2020-29582) |
| Medium | SCA | `org.jetbrains.kotlin:kotlin-stdlib` 1.5.21 — upgrade to 1.6.0+ (CVE-2022-24329) |
| Low | SAST | Potential file inclusion in `viewer.py` |
| Low | Secrets | Multiple test private keys in `3rdparty/mbedtls-*` (test fixtures, likely safe) |

---

*Generated by Aikido Security Fixer — 2026-07-29*